### PR TITLE
Fix some warnings in the example and loosen the version bound on base

### DIFF
--- a/examples/ekg-statsd-examples.cabal
+++ b/examples/ekg-statsd-examples.cabal
@@ -10,7 +10,7 @@ cabal-version:       >=1.10
 
 executable ekg-statsd-examples
   main-is:             Basic.hs
-  build-depends:       base >=4.6 && <4.7,
+  build-depends:       base >=4.6 && <4.10,
                        ekg-core,
                        ekg-statsd
   default-language:    Haskell2010


### PR DESCRIPTION
Fix some warnings in the example. Loosen the (relatively) antique version bound on base, which was `< 4.7`.