### PR TITLE
Add optional fullFlushIterations to StatsdOptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.2.1.2 (2017-09-18)
+
+ * Add extra `fullFlushIterations` option to control the amount
+   of data sent to `statsd`.
+
 ## 0.2.1.1 (2017-07-31)
 
  * Support GHC 8.2.1.

--- a/System/Remote/Monitoring/Statsd.hs
+++ b/System/Remote/Monitoring/Statsd.hs
@@ -170,7 +170,7 @@ loop store lastSample sendSample currentIteration opts = do
     -- and compute the diff between the previous and the current sample.
     let (!newIterationCount, !sample) =
           case fullFlushIterations opts of
-            Just x | currentIteration >= x -> (0, sample)
+            Just x | currentIteration >= x -> (0, currentSample)
             _  -> (currentIteration + 1, diffSamples lastSample currentSample)
     flushSample sample sendSample opts
     end <- time

--- a/System/Remote/Monitoring/Statsd.hs
+++ b/System/Remote/Monitoring/Statsd.hs
@@ -156,7 +156,7 @@ forkStatsd opts store = do
             return (sendSample, Socket.close socket)
 
     me <- myThreadId
-    tid <- forkFinally (loop store emptySample sendSample 0 opts) $ \ r -> do
+    tid <- forkFinally (loop store emptySample sendSample 1 opts) $ \ r -> do
         closeSocket
         case r of
             Left e  -> throwTo me e
@@ -182,7 +182,7 @@ loop store lastSample sendSample currentIteration opts = do
     flushSample flushMode sendSample opts
     end <- time
     threadDelay (flushInterval opts * 1000 - fromIntegral (end - start))
-    let !newIteration = if isFull flushMode then 0 else currentIteration + 1
+    let !newIteration = if isFull flushMode then 1 else currentIteration + 1
     loop store currentSample sendSample newIteration opts
 
 -- | Microseconds since epoch.

--- a/System/Remote/Monitoring/Statsd.hs
+++ b/System/Remote/Monitoring/Statsd.hs
@@ -77,7 +77,7 @@ data StatsdOptions = StatsdOptions
       -- | Set the number of iterations after which we perform
       -- a "full flush". If set to Nothing, ekg-statsd will be free
       -- to compute the difference between the previous samples and
-      -- the current one, sending to the daemon only metrics who changed.
+      -- the current one, sending to the daemon only metrics that changed.
       -- Setting `fullFlushIterations` to, for example, Just 100, would
       -- ensure that every 100 iterations of the main loop we would
       -- send the full "snapshot" of the metrics.
@@ -164,14 +164,14 @@ loop :: Metrics.Store            -- ^ Metric store
 loop store lastSample sendSample currentIteration opts = do
     start <- time
     currentSample <- Metrics.sampleAll store
-    -- Check wether or not we need to perform a "full flush", in
+    -- Check whether or not we need to perform a "full flush", in
     -- which case we reset the counter and send downstream to flushing
     -- the current snapshot of the `Store`, otherwise we increase the counter
     -- and compute the diff between the previous and the current sample.
     let (!newIterationCount, !sample) =
           case fullFlushIterations opts of
-            Just x | x >= currentIteration -> (0, sample)
-            _  -> (newIterationCount + 1, diffSamples lastSample currentSample)
+            Just x | currentIteration >= x -> (0, sample)
+            _  -> (currentIteration + 1, diffSamples lastSample currentSample)
     flushSample sample sendSample opts
     end <- time
     threadDelay (flushInterval opts * 1000 - fromIntegral (end - start))


### PR DESCRIPTION
Hey @tibbe!

This PR adds a new optional setting to `StatsdOptions` called `fullFlushIterations` (I suck at names! Feel free to propose something different). When non-Nothing, such setting would influence whether or not we flush the "full snapshot" of a `Store` or just the diff, as we were previously doing.

The rationale behind this is that there might be situations where users of the library might be interested in an even more fine-grained tuning of the network traffic. For example, a metric which hasn't reported recently can't be assumed to have the same value that was last reported. For all we know metrics may have stopped being reported or worse, a critical piece of the system is down and it can't notify us.

This is a very initial draft. @dcoutts suggested to separate out

```
    let (!newIterationCount, !sample) =
          case fullFlushIterations opts of
            Just x | x >= currentIteration -> (0, sample)
            _  -> (newIterationCount + 1, diffSamples lastSample currentSample)
```

Into something which would make the logic easier to follow. Suggestions are very welcome in this area, as well as any other feedback in general 😉 

Thanks!

Alfredo