### PR TITLE
Remove diffSample optimisation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.2.2.0 (2017-09-25)
+
+ * Remove internal `diffSample` optimisation and always report the full
+   state of the `Store` instead of only what's changed between iterations.
+
 ## 0.2.1.1 (2017-07-31)
 
  * Support GHC 8.2.1.


### PR DESCRIPTION
@23Skidoo @tibbe This PR removes the `diffSample` optimisation to allow `statsd` to pick us these "low-level" details for us, as client code shouldn't be bothered.

See here for a better description and the rational around this PR: https://github.com/tibbe/ekg-statsd/pull/16