### PR TITLE
Catch and rethrow exceptions using finally instead of forkFinally

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 0.2.4.0
+
+* Don't rethrow `ThreadKilled` exceptions to the thread that invoked
+  `forkStatsd`, so that the statsd thread can be safely killed
+  ([#20](https://github.com/tibbe/ekg-statsd/pull/20)).
+
 ## 0.2.3.0 (2018-04-10)
 
  * API addition: 'statsdFlush', allows to flush the sample to statsd

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.2.4.0 (2018-07-31)
+## 0.2.3.1 (2018-07-31)
 
 * Don't rethrow `ThreadKilled` exceptions to the thread that invoked
   `forkStatsd`, so that the statsd thread can be safely killed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.2.4.0
+## 0.2.4.0 (2018-07-31)
 
 * Don't rethrow `ThreadKilled` exceptions to the thread that invoked
   `forkStatsd`, so that the statsd thread can be safely killed


### PR DESCRIPTION
Using `finally` after the `forkIO` means that most exceptions will still be rethrown on the main thread, but `forkIO` will swallow `ThreadKilled` exceptions so they will no longer get rethrown.  Fixes #19.