### PR TITLE
Replace ':'s in metric name by '_'

### DIFF
--- a/System/Remote/Monitoring/Statsd.hs
+++ b/System/Remote/Monitoring/Statsd.hs
@@ -175,9 +175,13 @@ time = (round . (* 1000000.0) . toDouble) `fmap` getPOSIXTime
 flushSample :: Metrics.Sample -> (B8.ByteString -> IO ()) -> StatsdOptions -> IO ()
 flushSample sample sendSample opts = do
     forM_ (M.toList sample) $ \ (name, val) ->
-        let fullName = dottedPrefix <> name <> dottedSuffix
+        let fullName = dottedPrefix <> sanitizeName name <> dottedSuffix
         in  flushMetric fullName val
   where
+    sanitizeName = T.map sanitizeChar
+    sanitizeChar ':' = '_'
+    sanitizeChar c   = c
+
     flushMetric name (Metrics.Counter n)      = send "|c" name (show n)
     flushMetric name (Metrics.Gauge n)        = send "|g" name (show n)
     flushMetric name (Metrics.Distribution d) = sendDistribution name d

--- a/System/Remote/Monitoring/Statsd.hs
+++ b/System/Remote/Monitoring/Statsd.hs
@@ -13,6 +13,9 @@
 -- You probably want to include some of the predefined metrics defined
 -- in the ekg-core package, by calling e.g. the 'registerGcStats'
 -- function defined in that package.
+--
+-- Note that the StatsD protocol does not allow @':'@ in metric names, so
+-- any occurrences are replaced by @'_'@.
 module System.Remote.Monitoring.Statsd
     (
       -- * The statsd syncer


### PR DESCRIPTION
This allows ekg-statsd to be used with servant-ekg, which generates metrics like

    servant.path.accounts.:accountId.GET.time_ms.max:113.571281|g

So, having a colon in the metric name, terminating the name part too early.
Both StatsD and Dogstatsd behave like this.